### PR TITLE
Enhance RunCode function to support C++

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,11 +5,13 @@ import "huseynovvusal/gojudge/internal/judge"
 func main() {
 	// result, err := judge.RunCode("python", "n = 1\nwhile True:\n\tn += 1")
 	// result, err := judge.RunCode("python", "n = 1\nwhile (n < 100):\n\tn += 1; print(n)")
-	result, err := judge.RunCode("cpp", "#include <iostream>\nint main() {\n    int n = 1;\n    while (n < 5000) {\n        n++;\n        std::cout << n << std::endl;\n    }\n    return 0;\n}")
+	// result, err := judge.RunCode("cpp", "#include <iostream>\nint main() {\n    int n = 1;\n    while (n < 5000) {\n        n++;\n        std::cout << n << std::endl;\n    }\n    return 0;\n}")
+	result, err := judge.RunCode("c", "#include <stdio.h>\nint main() {\n    int n = 1;\n    while (n < 5000) {\n        n++;\n        printf(\"%d\\n\", n);\n    }\n    return 0;\n}")
 	if err != nil {
 		panic(err)
 	}
 
-	println("RESULT:" + result)
+	println("Output:\n" + result.Output)
+	println("Execution Time (ms):", result.ExecutionMs)
 
 }


### PR DESCRIPTION
This pull request introduces multi-language support and resource configuration improvements to the code execution system, along with an update to the main server example. The most significant changes are the addition of C++ support, dynamic resource allocation, and an increased execution timeout.

**Multi-language support and resource configuration:**

* Added support for executing both Python and C++ code in the `RunCode` function, including dynamic selection of Docker images, source file names, and commands based on the specified language. Unsupported languages now return an error.
* Changed temporary source file creation to use the correct file extension for each language, improving compatibility and correctness.
* Updated Docker container resource limits: reduced memory allocation from 512MB to 256MB, and increased CPU allocation from 0.05 to 0.5 CPU, allowing for more efficient and performant code execution.
* Increased code execution timeout from 1 second to 10 seconds to accommodate longer-running submissions.

**Example and dependency updates:**

* Updated the example in `cmd/server/main.go` to demonstrate running a C++ code submission instead of Python.
* Added import of `path/filepath` to support dynamic file extension handling.