### PR TITLE
Add support for Go language execution in RunCode function and implement RunGoWithNsjail

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,16 +7,22 @@ import (
 
 func main() {
 	// Python code to run a loop 10^5 times
-	// pythonCode := "n = int(input())\nfor i in range(n):\n\tprint(i)"
-	// result, err := judge.RunCode("python", pythonCode, "1000", 2, 256, 1)
+	// pythonCode := "n = int(1e3)\nfor i in range(n):\n\tprint(i)"
+	// result, err := judge.RunCode("python", pythonCode, "", 2, 256, 1)
+
 	// C code to run a loop 10^5 times
-	cCode := "#include <stdio.h>\nint main() {\n\tint n;\n\tscanf(\"%d\", &n);\n\tfor (int i = 0; i < n; i++) {\n\t\tprintf(\"%d\\n\", i);\n\t}\n\treturn 0;\n}"
-	result, err := judge.RunCode("c", cCode, "1000", 2, 256, 1)
+	// cCode := "#include <stdio.h>\nint main() {\n\tint n;\n\tscanf(\"%d\", &n);\n\tfor (int i = 0; i < n; i++) {\n\t\tprintf(\"%d\\n\", i);\n\t}\n\treturn 0;\n}"
+	// result, err := judge.RunCode("c", cCode, "1000", 2, 256, 1)
+
 	// C++ code to run a loop 10^5 times
 	// cppCode := "#include <iostream>\nusing namespace std;\nint main() {\n\tint n;\n\tcin >> n;\n\tfor (int i = 0; i < n; i++) {\n\t\tcout << i << endl;\n\t}\n\treturn 0;\n}"
 	// result, err := judge.RunCode("cpp", cppCode, "1000",
+
+	goCode := "package main\nimport \"fmt\"\nfunc main() {\n\tn := 1000\n\tfor i := 0; i < n; i++ {\n\t\tfmt.Println(i)\n\t}\n}"
+	result, err := judge.RunCode("go", goCode, "", 2, 1024, 1)
+
 	if err != nil {
-		fmt.Printf("Error: %v", err)
+		fmt.Printf("Error: %v\n", err)
 		return
 	}
 	println("Output:\n" + result.Output)


### PR DESCRIPTION
This pull request adds support for running Go code submissions in the judge system, alongside some minor improvements to existing test code. The main change involves implementing a new function to execute Go code securely using nsjail, and updating the language dispatch logic to recognize and handle Go submissions.

**Support for Go language execution:**

* Added a new function `RunGoWithNsjail` in `internal/judge/executor.go` to compile and execute Go code securely using nsjail, including resource limits and temporary file handling.
* Updated the main execution dispatch function in `internal/judge/executor.go` to call `RunGoWithNsjail` when the language is set to "go".

**Test and example updates:**

* Modified the Go server main file (`cmd/server/main.go`) to include an example of running Go code using the new judge logic, and made minor improvements to error output formatting.